### PR TITLE
Fix lucide-react imports to use proper type imports

### DIFF
--- a/src/components/home/PortfolioNav/PortfolioNavCard.tsx
+++ b/src/components/home/PortfolioNav/PortfolioNavCard.tsx
@@ -1,5 +1,5 @@
 import { motion, useReducedMotion } from 'framer-motion';
-import LucideIcon from 'lucide-react/dist/esm/icons/lucide-icon';
+import type { LucideIcon } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { Card } from '../../shared/Card';
 import { TranslationText } from '../../../components/shared/TranslationText';

--- a/src/components/home/PortfolioNav/index.tsx
+++ b/src/components/home/PortfolioNav/index.tsx
@@ -8,7 +8,7 @@ import { useLanguage } from '../../../context/LanguageContext';
 import { usePublicFeatureFlags } from '../../../lib/services/usePublicFeatureFlags';
 import { PortfolioNavCard } from './PortfolioNavCard';
 import { Card } from '../../shared/Card';
-import LucideIcon from 'lucide-react/dist/esm/icons/lucide-icon';
+import type { LucideIcon } from 'lucide-react';
 import { TranslationText } from '../../../components/shared/TranslationText';
 
 interface NavCard {

--- a/src/components/home/Statistics/StatCard.tsx
+++ b/src/components/home/Statistics/StatCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion, useReducedMotion } from 'framer-motion';
-import LucideIcon from 'lucide-react/dist/esm/icons/lucide-icon';
+import type { LucideIcon } from 'lucide-react';
 import { Card } from '../../shared/Card';
 
 interface StatCardProps {

--- a/src/components/home/Statistics/index.tsx
+++ b/src/components/home/Statistics/index.tsx
@@ -5,7 +5,7 @@ import TrendingUp from 'lucide-react/dist/esm/icons/trending-up';
 import { motion, useReducedMotion } from 'framer-motion';
 import { useLanguage } from '../../../context/LanguageContext';
 import { StatCard } from './StatCard';
-import LucideIcon from 'lucide-react/dist/esm/icons/lucide-icon';
+import type { LucideIcon } from 'lucide-react';
 import { TranslationText } from '../../../components/shared/TranslationText';
 
 interface Stat {

--- a/src/components/shared/PageHeader.tsx
+++ b/src/components/shared/PageHeader.tsx
@@ -1,5 +1,5 @@
-import LucideIcon from 'lucide-react/dist/esm/icons/lucide-icon';
-import ReactNode from 'lucide-react/dist/esm/icons/react-node';
+import type { LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
 
 interface PageHeaderProps {
   icon: LucideIcon;

--- a/src/components/shared/SectionHeader.tsx
+++ b/src/components/shared/SectionHeader.tsx
@@ -1,5 +1,5 @@
-import LucideIcon from 'lucide-react/dist/esm/icons/lucide-icon';
-import ReactNode from 'lucide-react/dist/esm/icons/react-node';
+import type { LucideIcon } from 'lucide-react';
+import type { ReactNode } from 'react';
 
 interface SectionHeaderProps {
   icon: LucideIcon;

--- a/src/utils/iconMap.ts
+++ b/src/utils/iconMap.ts
@@ -8,7 +8,7 @@ import Globe from 'lucide-react/dist/esm/icons/globe';
 import Lightbulb from 'lucide-react/dist/esm/icons/lightbulb';
 import Smartphone from 'lucide-react/dist/esm/icons/smartphone';
 import Table from 'lucide-react/dist/esm/icons/table';
-import LucideIcon from 'lucide-react/dist/esm/icons/lucide-icon';
+import type { LucideIcon } from 'lucide-react';
 
 export const iconMap: Record<string, LucideIcon> = {
   'Code2': Code2,


### PR DESCRIPTION
## Summary
Updated all lucide-react imports to use the correct import paths and type annotations. This fixes incorrect imports from the internal ESM distribution path and improves type safety.

## Key Changes
- Changed `LucideIcon` imports from `lucide-react/dist/esm/icons/lucide-icon` to `import type { LucideIcon } from 'lucide-react'`
- Fixed `ReactNode` import in `PageHeader.tsx` and `SectionHeader.tsx` from `lucide-react/dist/esm/icons/react-node` to `import type { ReactNode } from 'react'`
- Applied consistent type import syntax (`import type`) across all affected files

## Files Modified
- `src/components/home/PortfolioNav/PortfolioNavCard.tsx`
- `src/components/home/PortfolioNav/index.tsx`
- `src/components/home/Statistics/StatCard.tsx`
- `src/components/home/Statistics/index.tsx`
- `src/components/shared/PageHeader.tsx`
- `src/components/shared/SectionHeader.tsx`
- `src/utils/iconMap.ts`

## Implementation Details
- All type-only imports now use the `type` keyword, which helps with tree-shaking and makes the intent clear
- `ReactNode` is now correctly imported from React instead of lucide-react
- Maintains consistency with TypeScript best practices for type imports